### PR TITLE
Melhorias de qualidade de código, acessibilidade e UX

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,14 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
     },
   },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,4 +30,10 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ["src/components/ui/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": "off",
+    },
+  },
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/centro-oeste" element={<CentroOeste />} />

--- a/src/components/BrazilMapSVG.tsx
+++ b/src/components/BrazilMapSVG.tsx
@@ -138,9 +138,15 @@ const BrazilMapSVG = () => {
           return (
             <g
               key={state.code}
+              role={isClickable ? "button" : undefined}
+              tabIndex={isClickable ? 0 : undefined}
+              aria-label={isClickable ? `Navegar para a região ${region}` : undefined}
               onMouseEnter={() => setHoveredRegion(region || null)}
               onMouseLeave={() => setHoveredRegion(null)}
               onClick={() => handleClick(state.code)}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(state.code); } }}
+              onFocus={() => setHoveredRegion(region || null)}
+              onBlur={() => setHoveredRegion(null)}
               style={{ cursor: isClickable ? "pointer" : "default" }}
             >
               {state.paths.map((d, i) => (

--- a/src/components/BrazilMapSVG.tsx
+++ b/src/components/BrazilMapSVG.tsx
@@ -30,6 +30,16 @@ const regionLinks: Record<string, string> = {
   sul: "/sul",
 };
 
+const regionOrder = ["norte", "nordeste", "centroOeste", "sudeste", "sul"] as const;
+
+const regionDisplayNames: Record<string, string> = {
+  norte: "Norte",
+  nordeste: "Nordeste",
+  centroOeste: "Centro-Oeste",
+  sudeste: "Sudeste",
+  sul: "Sul",
+};
+
 interface StateData {
   code: string;
   paths: string[];
@@ -104,9 +114,7 @@ const BrazilMapSVG = () => {
     return "none";
   };
 
-  const handleClick = (code: string) => {
-    const region = stateToRegion[code];
-    if (!region) return;
+  const handleRegionClick = (region: string) => {
     const link = regionLinks[region];
     if (link && link !== "#") {
       if (link.startsWith("/")) {
@@ -130,52 +138,62 @@ const BrazilMapSVG = () => {
       className="w-full max-w-[820px] h-auto mx-auto block"
     >
       <g>
-        {states.map((state) => {
-          const region = stateToRegion[state.code];
-          const link = region ? regionLinks[region] : "#";
-          const isClickable = link && link !== "#";
+        {regionOrder.map((region) => {
+          const regionStates = states.filter((state) => stateToRegion[state.code] === region);
+          const link = regionLinks[region];
+          const isClickable = !!(link && link !== "#");
+          const regionLabel = regionDisplayNames[region] ?? region;
 
           return (
             <g
-              key={state.code}
+              key={region}
               role={isClickable ? "button" : undefined}
               tabIndex={isClickable ? 0 : undefined}
-              aria-label={isClickable ? `Navegar para a região ${region}` : undefined}
-              onMouseEnter={() => setHoveredRegion(region || null)}
+              aria-label={isClickable ? `Navegar para a região ${regionLabel}` : undefined}
+              onMouseEnter={() => setHoveredRegion(region)}
               onMouseLeave={() => setHoveredRegion(null)}
-              onClick={() => handleClick(state.code)}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(state.code); } }}
-              onFocus={() => setHoveredRegion(region || null)}
+              onClick={() => handleRegionClick(region)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleRegionClick(region);
+                }
+              }}
+              onFocus={() => setHoveredRegion(region)}
               onBlur={() => setHoveredRegion(null)}
               style={{ cursor: isClickable ? "pointer" : "default" }}
             >
-              {state.paths.map((d, i) => (
-                <path
-                  key={i}
-                  d={d}
-                  stroke="#FFFFFF"
-                  strokeWidth="1.0404"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  fill={getStateFill(state.code)}
-                  style={{ filter: getStateFilter(state.code), transition: "fill 0.2s ease, filter 0.2s ease" }}
-                />
+              {regionStates.map((state) => (
+                <g key={state.code}>
+                  {state.paths.map((d, i) => (
+                    <path
+                      key={i}
+                      d={d}
+                      stroke="#FFFFFF"
+                      strokeWidth="1.0404"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      fill={getStateFill(state.code)}
+                      style={{ filter: getStateFilter(state.code), transition: "fill 0.2s ease, filter 0.2s ease" }}
+                    />
+                  ))}
+                  {state.circlePath && (
+                    <path
+                      d={state.circlePath}
+                      fill="rgba(255, 255, 255, 0.3)"
+                      stroke="#ffffff"
+                      strokeWidth="1"
+                    />
+                  )}
+                  <text
+                    transform={state.textTransform}
+                    fill="#FFFFFF"
+                    style={{ font: "12px Arial, sans-serif", pointerEvents: "none", fontWeight: "bold" }}
+                  >
+                    {state.label}
+                  </text>
+                </g>
               ))}
-              {state.circlePath && (
-                <path
-                  d={state.circlePath}
-                  fill="rgba(255, 255, 255, 0.3)"
-                  stroke="#ffffff"
-                  strokeWidth="1"
-                />
-              )}
-              <text
-                transform={state.textTransform}
-                fill="#FFFFFF"
-                style={{ font: "12px Arial, sans-serif", pointerEvents: "none", fontWeight: "bold" }}
-              >
-                {state.label}
-              </text>
             </g>
           );
         })}

--- a/src/components/BrazilMapSVG.tsx
+++ b/src/components/BrazilMapSVG.tsx
@@ -30,8 +30,6 @@ const regionLinks: Record<string, string> = {
   sul: "/sul",
 };
 
-const hostStates = ["PA", "BA", "DF", "MG", "PR"];
-
 interface StateData {
   code: string;
   paths: string[];

--- a/src/components/BrazilMapSVG.tsx
+++ b/src/components/BrazilMapSVG.tsx
@@ -96,17 +96,28 @@ const hostCityData: Record<string, { city: string; date: string }> = {
   PA: { city: "Belém", date: "14 Nov" },
 };
 
-const BrazilMapSVG = () => {
+interface BrazilMapSVGProps {
+  outlineOnly?: boolean;
+  className?: string;
+}
+
+const BrazilMapSVG = ({ outlineOnly = false, className }: BrazilMapSVGProps) => {
   const [hoveredRegion, setHoveredRegion] = useState<string | null>(null);
   const [hoveredHost, setHoveredHost] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const getStateFill = (code: string) => {
+    if (outlineOnly) {
+      return "none";
+    }
     const region = stateToRegion[code];
     return region ? regionColors[region] : "#d8d8d8";
   };
 
   const getStateFilter = (code: string) => {
+    if (outlineOnly) {
+      return "none";
+    }
     const region = stateToRegion[code];
     if (hoveredRegion && region === hoveredRegion) {
       return "brightness(0.85)";
@@ -135,71 +146,100 @@ const BrazilMapSVG = () => {
       height="460px"
       viewBox="0 0 450 460"
       enableBackground="new 0 0 450 460"
-      className="w-full max-w-[820px] h-auto mx-auto block"
+      className={className ?? "w-full max-w-[820px] h-auto mx-auto block"}
     >
+      {outlineOnly && (
+        <defs>
+          <filter id="brazil-outline-filter" x="-10%" y="-10%" width="120%" height="120%" colorInterpolationFilters="sRGB">
+            <feMorphology in="SourceAlpha" operator="dilate" radius="1.4" result="dilated" />
+            <feMorphology in="SourceAlpha" operator="erode" radius="1.1" result="eroded" />
+            <feComposite in="dilated" in2="eroded" operator="out" result="outline" />
+            <feFlood floodColor="hsl(var(--accent))" floodOpacity="0.7" result="outlineColor" />
+            <feComposite in="outlineColor" in2="outline" operator="in" result="coloredOutline" />
+            <feMerge>
+              <feMergeNode in="coloredOutline" />
+            </feMerge>
+          </filter>
+        </defs>
+      )}
       <g>
-        {regionOrder.map((region) => {
-          const regionStates = states.filter((state) => stateToRegion[state.code] === region);
-          const link = regionLinks[region];
-          const isClickable = !!(link && link !== "#");
-          const regionLabel = regionDisplayNames[region] ?? region;
+        {outlineOnly && (
+          <g filter="url(#brazil-outline-filter)">
+            {states.map((state) => (
+              <g key={`outline-${state.code}`}>
+                {state.paths.map((d, i) => (
+                  <path key={i} d={d} fill="#ffffff" stroke="none" />
+                ))}
+              </g>
+            ))}
+          </g>
+        )}
+        {!outlineOnly && (
+          <>
+            {regionOrder.map((region) => {
+              const regionStates = states.filter((state) => stateToRegion[state.code] === region);
+              const link = regionLinks[region];
+              const isClickable = !!(link && link !== "#");
+              const regionLabel = regionDisplayNames[region] ?? region;
 
-          return (
-            <g
-              key={region}
-              role={isClickable ? "button" : undefined}
-              tabIndex={isClickable ? 0 : undefined}
-              aria-label={isClickable ? `Navegar para a região ${regionLabel}` : undefined}
-              onMouseEnter={() => setHoveredRegion(region)}
-              onMouseLeave={() => setHoveredRegion(null)}
-              onClick={() => handleRegionClick(region)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleRegionClick(region);
-                }
-              }}
-              onFocus={() => setHoveredRegion(region)}
-              onBlur={() => setHoveredRegion(null)}
-              style={{ cursor: isClickable ? "pointer" : "default" }}
-            >
-              {regionStates.map((state) => (
-                <g key={state.code}>
-                  {state.paths.map((d, i) => (
-                    <path
-                      key={i}
-                      d={d}
-                      stroke="#FFFFFF"
-                      strokeWidth="1.0404"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      fill={getStateFill(state.code)}
-                      style={{ filter: getStateFilter(state.code), transition: "fill 0.2s ease, filter 0.2s ease" }}
-                    />
+              return (
+                <g
+                  key={region}
+                  role={isClickable ? "button" : undefined}
+                  tabIndex={isClickable ? 0 : undefined}
+                  aria-label={isClickable ? `Navegar para a região ${regionLabel}` : undefined}
+                  onMouseEnter={() => setHoveredRegion(region)}
+                  onMouseLeave={() => setHoveredRegion(null)}
+                  onClick={() => handleRegionClick(region)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleRegionClick(region);
+                    }
+                  }}
+                  onFocus={() => setHoveredRegion(region)}
+                  onBlur={() => setHoveredRegion(null)}
+                  style={{ cursor: isClickable ? "pointer" : "default" }}
+                >
+                  {regionStates.map((state) => (
+                    <g key={state.code}>
+                      {state.paths.map((d, i) => (
+                        <path
+                          key={i}
+                          d={d}
+                          stroke="#FFFFFF"
+                          strokeWidth="1.0404"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill={getStateFill(state.code)}
+                          style={{ filter: getStateFilter(state.code), transition: "fill 0.2s ease, filter 0.2s ease" }}
+                        />
+                      ))}
+                      {state.circlePath && (
+                        <path
+                          d={state.circlePath}
+                          fill="rgba(255, 255, 255, 0.3)"
+                          stroke="#ffffff"
+                          strokeWidth="1"
+                        />
+                      )}
+                      <text
+                        transform={state.textTransform}
+                        fill="#FFFFFF"
+                        style={{ font: "12px Arial, sans-serif", pointerEvents: "none", fontWeight: "bold" }}
+                      >
+                        {state.label}
+                      </text>
+                    </g>
                   ))}
-                  {state.circlePath && (
-                    <path
-                      d={state.circlePath}
-                      fill="rgba(255, 255, 255, 0.3)"
-                      stroke="#ffffff"
-                      strokeWidth="1"
-                    />
-                  )}
-                  <text
-                    transform={state.textTransform}
-                    fill="#FFFFFF"
-                    style={{ font: "12px Arial, sans-serif", pointerEvents: "none", fontWeight: "bold" }}
-                  >
-                    {state.label}
-                  </text>
                 </g>
-              ))}
-            </g>
-          );
-        })}
+              );
+            })}
+          </>
+        )}
 
         {/* Host city markers */}
-        {Object.entries(hostMarkerPositions).map(([uf, pos]) => {
+        {!outlineOnly && Object.entries(hostMarkerPositions).map(([uf, pos]) => {
           const markerX = pos.x + 9;
           const markerY = pos.y - 20;
           const isHovered = hoveredHost === uf;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,14 +26,16 @@ const Header = () => {
         <button
           className="md:hidden p-2 text-foreground"
           onClick={() => setMenuOpen(!menuOpen)}
-          aria-label="Menu"
+          aria-label={menuOpen ? "Fechar menu" : "Abrir menu"}
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav"
         >
           {menuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>
       {menuOpen && (
         <div className="md:hidden bg-background/95 backdrop-blur-md border-b border-border">
-          <nav className="container flex flex-col gap-4 py-4">
+          <nav id="mobile-nav" className="container flex flex-col gap-4 py-4">
             {navLinks.map((link) => (
               <a
                 key={link.href}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,35 +1,5 @@
 import logo from "@/assets/logo-community-day.png";
-
-const BrazilMapSVG = () => (
-  <svg viewBox="0 0 600 600" className="w-full h-full opacity-10" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Simplified Brazil outline */}
-    <path
-      d="M300 80 L380 100 L420 140 L450 180 L480 200 L500 260 L490 320 L470 360 L440 400 L400 440 L360 470 L320 490 L280 500 L240 490 L200 460 L180 420 L160 380 L150 340 L140 300 L150 260 L170 220 L200 180 L240 140 L280 100 Z"
-      stroke="hsl(var(--accent))"
-      strokeWidth="1"
-      opacity="0.5"
-    />
-    {/* Connection nodes */}
-    {[
-      [300, 180], [380, 260], [450, 300], [260, 340], [340, 400],
-      [200, 280], [320, 240], [400, 350], [280, 450], [360, 160],
-    ].map(([cx, cy], i) => (
-      <g key={i}>
-        <circle cx={cx} cy={cy} r="3" fill="hsl(var(--primary))" opacity="0.6" />
-        <circle cx={cx} cy={cy} r="8" fill="none" stroke="hsl(var(--primary))" strokeWidth="0.5" opacity="0.3" />
-      </g>
-    ))}
-    {/* Connection lines */}
-    {[
-      [300, 180, 380, 260], [380, 260, 450, 300], [300, 180, 260, 340],
-      [260, 340, 340, 400], [200, 280, 300, 180], [320, 240, 400, 350],
-      [340, 400, 280, 450], [380, 260, 360, 160], [450, 300, 400, 350],
-    ].map(([x1, y1, x2, y2], i) => (
-      <line key={i} x1={x1} y1={y1} x2={x2} y2={y2}
-        stroke="hsl(var(--accent))" strokeWidth="0.5" opacity="0.3" />
-    ))}
-  </svg>
-);
+import BrazilMapSVG from "./BrazilMapSVG";
 
 const HeroSection = () => {
   return (
@@ -37,7 +7,7 @@ const HeroSection = () => {
       style={{ background: "var(--gradient-hero)" }}>
       <div className="absolute inset-0 flex items-center justify-center hero-fade-in" style={{ animationDelay: "0.3s" }}>
         <div className="w-[600px] h-[600px]">
-          <BrazilMapSVG />
+          <BrazilMapSVG outlineOnly className="w-full h-full opacity-10" />
         </div>
       </div>
       <div className="relative z-10 text-center container">

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -42,8 +42,8 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ..._props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ..._props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -12,7 +12,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
-const actionTypes = {
+const _actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",
   DISMISS_TOAST: "DISMISS_TOAST",
@@ -26,7 +26,7 @@ function genId() {
   return count.toString();
 }
 
-type ActionType = typeof actionTypes;
+type ActionType = typeof _actionTypes;
 
 type Action =
   | {

--- a/src/regions/components/RegionHeader.tsx
+++ b/src/regions/components/RegionHeader.tsx
@@ -64,13 +64,19 @@ const RegionHeader = ({ registrationUrl }: RegionHeaderProps) => {
             Inscreva-se
           </a>
         )}
-        <button className="md:hidden p-2 text-foreground" onClick={() => setMobileMenuOpen(!mobileMenuOpen)} aria-label="Menu">
+        <button
+          className="md:hidden p-2 text-foreground"
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          aria-label={mobileMenuOpen ? "Fechar menu" : "Abrir menu"}
+          aria-expanded={mobileMenuOpen}
+          aria-controls="region-mobile-nav"
+        >
           {mobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>
       {mobileMenuOpen && (
         <div className="md:hidden bg-card/95 backdrop-blur-md border-b border-border">
-          <nav className="container flex flex-col gap-2 py-4">
+          <nav id="region-mobile-nav" className="container flex flex-col gap-2 py-4">
             {navSections.map(({ id, label }) => (
               <a
                 key={id}

--- a/src/regions/components/RegionHero.tsx
+++ b/src/regions/components/RegionHero.tsx
@@ -3,21 +3,24 @@ import { useScrollAnimation } from "@/hooks/use-scroll-animation";
 import logo from "@/assets/logo-community-day.png";
 import type { RegionConfig } from "@/regions/types";
 
-function useCountdown(targetDate: string) {
-  const calc = () => {
-    const diff = Math.max(0, new Date(targetDate).getTime() - Date.now());
-    return {
-      days: Math.floor(diff / 86400000),
-      hours: Math.floor((diff % 86400000) / 3600000),
-      minutes: Math.floor((diff % 3600000) / 60000),
-      seconds: Math.floor((diff % 60000) / 1000),
-    };
+const getCountdown = (targetDate: string) => {
+  const diff = Math.max(0, new Date(targetDate).getTime() - Date.now());
+  return {
+    days: Math.floor(diff / 86400000),
+    hours: Math.floor((diff % 86400000) / 3600000),
+    minutes: Math.floor((diff % 3600000) / 60000),
+    seconds: Math.floor((diff % 60000) / 1000),
   };
-  const [time, setTime] = useState(calc);
+};
+
+function useCountdown(targetDate: string) {
+  const [time, setTime] = useState(() => getCountdown(targetDate));
+
   useEffect(() => {
-    const id = setInterval(() => setTime(calc()), 1000);
+    const id = setInterval(() => setTime(getCountdown(targetDate)), 1000);
     return () => clearInterval(id);
   }, [targetDate]);
+
   return time;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -73,5 +74,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,16 +14,16 @@
     "moduleResolution": "bundler",
     "noEmit": true,
     "noFallthroughCasesInSwitch": false,
-    "noImplicitAny": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "paths": {
       "@/*": [
         "./src/*"
       ]
     },
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "target": "ES2020",
     "types": [
       "vitest/globals"


### PR DESCRIPTION
### TypeScript & ESLint
- Habilitado `strict: true`, `noImplicitAny`, `noUnusedLocals` e `noUnusedParameters` no tsconfig.app.json
- Reativado a regra `@typescript-eslint/no-unused-vars` com convenção de prefixo `_` para exceções
- Override de `react-refresh/only-export-components` apenas para `src/components/ui/**` (componentes gerados pelo shadcn/ui)
- Corrigidos todos os erros e warnings resultantes em múltiplos arquivos (`use-toast.ts`, `command.tsx`, `textarea.tsx`, `calendar.tsx`, tailwind.config.ts)

### React Router
- Adicionados future flags `v7_relativeSplatPath` e `v7_startTransition` ao `BrowserRouter` para eliminar warnings de console sobre a migração para v7

### Acessibilidade
- `BrazilMapSVG`: adicionados `role="button"`, `tabIndex={0}`, `aria-label` e suporte a teclado (Enter/Space) em cada grupo de região interativa
- `Header`: botão do menu mobile com `aria-expanded`, `aria-controls` e `aria-label` dinâmico; `<nav>` com `id` correspondente
- `RegionHeader`: mesmo padrão de ARIA aplicado ao menu mobile das páginas de região

### Mapa interativo
- Refatorado de interação por estado (27 grupos) para interação por região (5 grupos: Norte, Nordeste, Centro-Oeste, Sudeste, Sul)
- Cada região possui cor, marcador de cidade-sede e tooltip dedicados

### Hero Section
- Adicionada prop `outlineOnly` ao `BrazilMapSVG`
- Quando ativa, renderiza o contorno externo real do Brasil usando filtro SVG (`feMorphology` dilate → erode → composite) sobre os paths reais dos estados
- `HeroSection` exibe o mapa como elemento decorativo de fundo com apenas a linha do contorno do país

### Resultado
- `npm run lint`: 0 erros, 0 warnings
- `tsc --noEmit`: 0 erros


<img width="1174" height="726" alt="image" src="https://github.com/user-attachments/assets/8a259e6f-450c-47b6-8e91-22d1bc461596" />
 