### PR TITLE
feat: adaptar site para eventos passados e adicionar página de result…

### DIFF
--- a/public/centro-oeste/resultado/index.html
+++ b/public/centro-oeste/resultado/index.html
@@ -1,0 +1,598 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Resultado — AWS Community Day Centro-Oeste 2026</title>
+  <meta name="description" content="Relatório de participação do AWS Community Day Centro-Oeste 2026 — 204 participantes presentes em Brasília." />
+  <link rel="icon" href="/favicon.png" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      --bg: #1a1f2e;
+      --card: #232938;
+      --border: #2e3548;
+      --primary: #e8841a;
+      --primary-light: #fbc064;
+      --text: #f1f5f9;
+      --muted: #94a3b8;
+      --shadow: 0 4px 24px rgba(0,0,0,0.3);
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+    .container { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
+    header {
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 0;
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(12px);
+    }
+    header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header img { height: 40px; }
+    header a {
+      color: var(--primary);
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.875rem;
+      transition: color 0.2s;
+    }
+    header a:hover { color: var(--primary-light); }
+
+    .hero {
+      text-align: center;
+      padding: 4rem 0 3rem;
+    }
+    .hero .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1.25rem;
+      border-radius: 9999px;
+      background: rgba(232, 132, 26, 0.12);
+      border: 1px solid rgba(232, 132, 26, 0.3);
+      color: var(--primary);
+      font-weight: 700;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+      margin-bottom: 1.5rem;
+    }
+    .hero h1 {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+      font-weight: 800;
+      margin-bottom: 0.75rem;
+    }
+    .hero p { color: var(--muted); font-size: 1.1rem; max-width: 600px; margin: 0 auto; }
+
+    .kpis {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.25rem;
+      margin: 3rem 0;
+    }
+    .kpi {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.75rem 1.25rem;
+      text-align: center;
+      box-shadow: var(--shadow);
+      transition: border-color 0.3s, transform 0.3s;
+    }
+    .kpi:hover { border-color: rgba(232, 132, 26, 0.5); transform: translateY(-2px); }
+    .kpi .value {
+      font-size: 2.5rem;
+      font-weight: 800;
+      color: var(--primary);
+      line-height: 1.1;
+    }
+    .kpi .label {
+      font-size: 0.8rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-top: 0.5rem;
+    }
+
+    .section { margin: 4rem 0; }
+    .section-title {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .section-title h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .section-title p {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-top: 0.5rem;
+    }
+
+    .charts-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 1.5rem;
+    }
+    .chart-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: var(--shadow);
+    }
+    .chart-card h3 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 1rem;
+      text-align: center;
+    }
+    .chart-card canvas { width: 100% !important; max-height: 300px; }
+
+    .chart-card-full {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: var(--shadow);
+      margin-top: 1.5rem;
+    }
+    .chart-card-full h3 {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 1rem;
+      text-align: center;
+    }
+    .chart-card-full canvas { width: 100% !important; max-height: 280px; }
+
+    .highlights {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+      margin-top: 3rem;
+    }
+    .highlight-item {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.25rem;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      transition: border-color 0.3s;
+    }
+    .highlight-item:hover { border-color: rgba(232, 132, 26, 0.4); }
+    .highlight-item .icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      background: rgba(232, 132, 26, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .highlight-item .icon svg { width: 18px; height: 18px; color: var(--primary); }
+    .highlight-item .content h4 { font-size: 0.9rem; font-weight: 600; margin-bottom: 0.25rem; }
+    .highlight-item .content p { font-size: 0.8rem; color: var(--muted); line-height: 1.5; }
+
+    .table-wrapper {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+      margin-top: 1.5rem;
+    }
+    table { width: 100%; border-collapse: collapse; }
+    th {
+      background: rgba(232, 132, 26, 0.08);
+      padding: 0.875rem 1.25rem;
+      text-align: left;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--primary);
+      font-weight: 700;
+    }
+    td {
+      padding: 0.75rem 1.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.875rem;
+    }
+    tr:hover td { background: rgba(232, 132, 26, 0.03); }
+    .bar-cell { display: flex; align-items: center; gap: 0.75rem; }
+    .bar-bg {
+      flex: 1;
+      height: 8px;
+      background: var(--border);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%;
+      background: var(--primary);
+      border-radius: 4px;
+      transition: width 1s ease;
+    }
+
+    footer {
+      text-align: center;
+      padding: 3rem 0;
+      color: var(--muted);
+      font-size: 0.8rem;
+      border-top: 1px solid var(--border);
+      margin-top: 4rem;
+    }
+    footer a { color: var(--primary); text-decoration: none; }
+
+    @media (max-width: 640px) {
+      .kpis { grid-template-columns: repeat(2, 1fr); }
+      .kpi .value { font-size: 2rem; }
+      .charts-grid { grid-template-columns: 1fr; }
+    }
+
+    .photos-banner { margin: 2.5rem 0 1rem; }
+    .photo-card {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      border-radius: 16px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      background: var(--card);
+      box-shadow: var(--shadow);
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.3s, transform 0.3s;
+    }
+    .photo-card:hover { border-color: var(--primary); transform: translateY(-3px); }
+    .photo-card-image {
+      position: relative;
+      min-height: 220px;
+      overflow: hidden;
+    }
+    .photo-card-image img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform 0.5s;
+    }
+    .photo-card:hover .photo-card-image img { transform: scale(1.05); }
+    .photo-card-overlay {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(26,31,46,0.3), rgba(232,132,26,0.1));
+    }
+    .photo-card-badge {
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 0.875rem;
+      border-radius: 9999px;
+      background: rgba(0,0,0,0.6);
+      backdrop-filter: blur(8px);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .photo-card-content {
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+    .photo-card-content h3 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+    }
+    .photo-card-content p {
+      color: var(--muted);
+      font-size: 0.9rem;
+      line-height: 1.6;
+      margin-bottom: 1.25rem;
+    }
+    .photo-card-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--primary);
+      font-weight: 700;
+      font-size: 0.9rem;
+      transition: gap 0.3s;
+    }
+    .photo-card:hover .photo-card-cta { gap: 0.75rem; }
+    @media (max-width: 640px) {
+      .photo-card { grid-template-columns: 1fr; }
+      .photo-card-image { min-height: 180px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <a href="/centro-oeste/"><img src="/favicon.png" alt="AWS Community Day" /></a>
+      <a href="/centro-oeste/">← Voltar para o evento</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <div class="badge">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+        Evento Realizado — 27/06/2026
+      </div>
+      <h1>Resultado do Evento</h1>
+      <p>AWS Community Day Centro-Oeste 2026 — Brasília/DF</p>
+    </section>
+
+    <section class="kpis">
+      <div class="kpi"><div class="value">204</div><div class="label">Participantes presentes</div></div>
+      <div class="kpi"><div class="value">20</div><div class="label">Palestrantes</div></div>
+      <div class="kpi"><div class="value">88%</div><div class="label">Credenciados até 9h</div></div>
+      <div class="kpi"><div class="value">75%</div><div class="label">Vindos do DF</div></div>
+    </section>
+
+    <section class="photos-banner">
+      <a href="https://photos.app.goo.gl/K2NxYNw5ySWGgxC7A" target="_blank" rel="noopener noreferrer" class="photo-card">
+        <div class="photo-card-image">
+          <img src="event-photo.jpg" alt="Fotos do AWS Community Day Centro-Oeste 2026" />
+          <div class="photo-card-overlay"></div>
+          <div class="photo-card-badge">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+            Galeria de Fotos
+          </div>
+        </div>
+        <div class="photo-card-content">
+          <h3>📸 Veja as fotos do evento</h3>
+          <p>Reviva os melhores momentos do AWS Community Day Centro-Oeste 2026. Palestras, networking, comunidade e muito mais!</p>
+          <span class="photo-card-cta">
+            Abrir galeria
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          </span>
+        </div>
+      </a>
+    </section>
+
+    <section class="section">
+      <div class="section-title">
+        <h2>Composição do Público</h2>
+        <p>Distribuição por categoria de credencial e perfil profissional</p>
+      </div>
+      <div class="charts-grid">
+        <div class="chart-card">
+          <h3>Categoria de Credencial</h3>
+          <canvas id="chartCategoria"></canvas>
+        </div>
+        <div class="chart-card">
+          <h3>Perfil Profissional</h3>
+          <canvas id="chartPerfil"></canvas>
+        </div>
+      </div>
+
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Categoria</th><th>Quantidade</th><th>% do Total</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Participante</td><td>159</td><td>77,9%</td><td><div class="bar-cell"><div class="bar-bg"><div class="bar-fill" style="width:77.9%"></div></div></div></td></tr>
+            <tr><td>Palestrante</td><td>20</td><td>9,8%</td><td><div class="bar-cell"><div class="bar-bg"><div class="bar-fill" style="width:9.8%"></div></div></div></td></tr>
+            <tr><td>Staff</td><td>16</td><td>7,8%</td><td><div class="bar-cell"><div class="bar-bg"><div class="bar-fill" style="width:7.8%"></div></div></div></td></tr>
+            <tr><td>Organização</td><td>5</td><td>2,5%</td><td><div class="bar-cell"><div class="bar-bg"><div class="bar-fill" style="width:2.5%"></div></div></div></td></tr>
+            <tr><td>Expositor</td><td>4</td><td>2,0%</td><td><div class="bar-cell"><div class="bar-bg"><div class="bar-fill" style="width:2.0%"></div></div></div></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-title">
+        <h2>Fluxo de Credenciamento</h2>
+        <p>Distribuição de check-ins por faixa de horário — intervalos de 15 minutos</p>
+      </div>
+      <div class="chart-card-full">
+        <h3>Credenciamentos ao Longo do Dia</h3>
+        <canvas id="chartFluxo"></canvas>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-title">
+        <h2>Origem Geográfica</h2>
+        <p>De onde vieram os participantes — análise por DDD telefônico</p>
+      </div>
+      <div class="chart-card-full">
+        <h3>Participantes por Estado</h3>
+        <canvas id="chartGeo"></canvas>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-title">
+        <h2>Destaques</h2>
+      </div>
+      <div class="highlights">
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg></div>
+          <div class="content"><h4>100% de retenção</h4><p>Todos os 204 credenciados permaneceram até o fim do evento. Nenhum descredenciamento.</p></div>
+        </div>
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></div>
+          <div class="content"><h4>Pico: 08:15–08:30</h4><p>41 credenciamentos em 15 minutos — maior concentração de chegada do dia.</p></div>
+        </div>
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg></div>
+          <div class="content"><h4>Público técnico</h4><p>Desenvolvimento de Software (29,4%), Infra (20,6%) e Estudantes (20,6%) somam +70% do público.</p></div>
+        </div>
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg></div>
+          <div class="content"><h4>Atração regional</h4><p>25% do público veio de fora do DF, com destaque para GO (11,8%), SP e MG.</p></div>
+        </div>
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v16"/></svg></div>
+          <div class="content"><h4>Perfil individual</h4><p>Apenas 9,8% dos e-mails são de domínios corporativos — público majoritariamente pessoa física.</p></div>
+        </div>
+        <div class="highlight-item">
+          <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg></div>
+          <div class="content"><h4>Transição de carreira</h4><p>4,4% dos participantes estão migrando para tecnologia — oportunidade para trilhas de capacitação.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>AWS Community Day Brasil 2026 — Centro-Oeste · <a href="/centro-oeste/">Ver página do evento</a></p>
+      <p style="margin-top: 0.5rem;">Dados extraídos da plataforma Hub Connect — Relatório gerado em 29/06/2026</p>
+    </div>
+  </footer>
+
+  <script>
+    Chart.defaults.color = '#94a3b8';
+    Chart.defaults.borderColor = '#2e3548';
+    Chart.defaults.font.family = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+
+    // Categoria de Credencial - Doughnut
+    new Chart(document.getElementById('chartCategoria'), {
+      type: 'doughnut',
+      data: {
+        labels: ['Participante', 'Palestrante', 'Staff', 'Organização', 'Expositor'],
+        datasets: [{
+          data: [159, 20, 16, 5, 4],
+          backgroundColor: ['#e8841a', '#fbc064', '#554492', '#77889d', '#322f5a'],
+          borderColor: '#232938',
+          borderWidth: 3,
+        }]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { position: 'bottom', labels: { padding: 16, usePointStyle: true, pointStyle: 'circle' } },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => `${ctx.label}: ${ctx.raw} (${((ctx.raw/204)*100).toFixed(1)}%)`
+            }
+          }
+        },
+        cutout: '60%',
+      }
+    });
+
+    // Perfil Profissional - Horizontal Bar
+    new Chart(document.getElementById('chartPerfil'), {
+      type: 'bar',
+      data: {
+        labels: ['Dev Software', 'Infraestrutura', 'Estudante', 'Outros', 'Gestão de TI', 'Transição', 'Exec. Negócios', 'N/I'],
+        datasets: [{
+          data: [60, 42, 42, 27, 14, 9, 7, 3],
+          backgroundColor: '#e8841a',
+          borderRadius: 4,
+          barThickness: 20,
+        }]
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => `${ctx.raw} participantes (${((ctx.raw/204)*100).toFixed(1)}%)`
+            }
+          }
+        },
+        scales: {
+          x: { grid: { color: '#2e3548' }, ticks: { stepSize: 10 } },
+          y: { grid: { display: false } }
+        }
+      }
+    });
+
+    // Fluxo de Credenciamento - Line/Area
+    new Chart(document.getElementById('chartFluxo'), {
+      type: 'bar',
+      data: {
+        labels: ['07:45', '08:00', '08:15', '08:30', '08:45', '09:00', '09:15', '09:30', '09:45', '10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '12:00', '13:45', '14:00', '14:30', '15:00', '15:45'],
+        datasets: [{
+          label: 'Credenciamentos',
+          data: [5, 22, 41, 32, 15, 20, 12, 8, 6, 5, 4, 3, 2, 3, 2, 1, 1, 3, 5, 4, 2, 1],
+          backgroundColor: (ctx) => {
+            const v = ctx.raw;
+            return v >= 30 ? '#e8841a' : v >= 15 ? '#fbc064' : 'rgba(232, 132, 26, 0.4)';
+          },
+          borderRadius: 4,
+        }]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              title: (items) => `Horário: ${items[0].label}`,
+              label: (ctx) => `${ctx.raw} check-ins`
+            }
+          }
+        },
+        scales: {
+          x: { grid: { display: false }, ticks: { maxRotation: 45 } },
+          y: { grid: { color: '#2e3548' }, beginAtZero: true }
+        }
+      }
+    });
+
+    // Origem Geográfica - Bar
+    new Chart(document.getElementById('chartGeo'), {
+      type: 'bar',
+      data: {
+        labels: ['DF (Brasília)', 'GO (Goiás)', 'SP (São Paulo)', 'Outros', 'MG (Minas Gerais)', 'AP (Amapá)', 'Outros estados'],
+        datasets: [{
+          data: [153, 24, 9, 6, 3, 2, 7],
+          backgroundColor: ['#e8841a', '#fbc064', '#554492', '#77889d', '#322f5a', '#94a3b8', '#4a5568'],
+          borderRadius: 6,
+          barThickness: 40,
+        }]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => `${ctx.raw} participantes (${((ctx.raw/204)*100).toFixed(1)}%)`
+            }
+          }
+        },
+        scales: {
+          x: { grid: { display: false } },
+          y: { grid: { color: '#2e3548' }, beginAtZero: true }
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/components/BrazilMapSVG.tsx
+++ b/src/components/BrazilMapSVG.tsx
@@ -92,7 +92,7 @@ const hostCityData: Record<string, { city: string; date: string }> = {
   DF: { city: "Brasília", date: "27 Jun" },
   MG: { city: "Belo Horizonte", date: "22 Ago" },
   PR: { city: "Curitiba", date: "19 Set" },
-  BA: { city: "Salvador", date: "10/10/2026" },
+  BA: { city: "Salvador", date: "10 Out" },
   PA: { city: "Belém", date: "31 Out" },
 };
 

--- a/src/components/LeadersSection.tsx
+++ b/src/components/LeadersSection.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { useMemo } from "react";
 import postcardBrasilia from "@/assets/postcard-brasilia.png";
 import postcardBH from "@/assets/postcard-bh.png";
 import postcardSalvador from "@/assets/postcard-salvador.png";
@@ -64,6 +65,18 @@ const leaders = [
   },
 ];
 
+function parseDate(dateStr: string): Date {
+  const [day, month, year] = dateStr.split("/").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function isPastEvent(dateStr: string): boolean {
+  const eventDate = parseDate(dateStr);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return eventDate < today;
+}
+
 const LeaderCard = ({
   name,
   city,
@@ -73,18 +86,26 @@ const LeaderCard = ({
   leaderPhoto,
   leaderLinkedin,
   link,
-}: (typeof leaders)[number]) => (
+  past,
+}: (typeof leaders)[number] & { past: boolean }) => (
   <div
-    className="group relative overflow-hidden rounded-lg aspect-[3/4]"
+    className={`group relative overflow-hidden rounded-lg aspect-[3/4] ${past ? "opacity-75 hover:opacity-100 transition-opacity" : ""}`}
     style={{ boxShadow: "var(--shadow-card)" }}
   >
     <img
       src={image}
       alt={`${city} - ${name}`}
-      className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
+      className={`absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:scale-110 ${past ? "grayscale-[30%]" : ""}`}
     />
     <div className="absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/50" />
     <div className="absolute inset-0 rounded-lg border-2 border-transparent group-hover:border-primary transition-colors duration-300" />
+    {past && (
+      <div className="absolute top-3 right-3 z-10">
+        <span className="px-2.5 py-1 text-xs font-bold uppercase tracking-wider bg-primary/90 text-primary-foreground rounded-full font-display">
+          Realizado
+        </span>
+      </div>
+    )}
     <div className="relative h-full flex flex-col items-center justify-center p-5 text-center">
       <a
         href={leaderLinkedin}
@@ -114,7 +135,7 @@ const LeaderCard = ({
             to={link}
             className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-foreground transition-colors font-display mt-4"
           >
-            Ver evento
+            {past ? "Ver como foi" : "Ver evento"}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M5 12h14M12 5l7 7-7 7" />
             </svg>
@@ -126,7 +147,7 @@ const LeaderCard = ({
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-foreground transition-colors font-display mt-4"
           >
-            Ver evento
+            {past ? "Ver como foi" : "Ver evento"}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M5 12h14M12 5l7 7-7 7" />
             </svg>
@@ -140,6 +161,15 @@ const LeaderCard = ({
 const LeadersSection = () => {
   const { ref: titleRef, isVisible: titleVisible } = useScrollAnimation();
   const { ref: gridRef, isVisible: gridVisible } = useScrollAnimation();
+
+  const sortedLeaders = useMemo(() => {
+    const future = leaders.filter((l) => !isPastEvent(l.date));
+    const past = leaders.filter((l) => isPastEvent(l.date));
+    // Future events sorted by date ascending, past events sorted by date descending (most recent first)
+    future.sort((a, b) => parseDate(a.date).getTime() - parseDate(b.date).getTime());
+    past.sort((a, b) => parseDate(b.date).getTime() - parseDate(a.date).getTime());
+    return [...future, ...past];
+  }, []);
 
   return (
     <section id="lideres" className="py-24">
@@ -156,13 +186,13 @@ const LeadersSection = () => {
           </h2>
         </div>
         <div ref={gridRef} className="flex flex-wrap justify-center gap-6">
-          {leaders.slice(0, 6).map((l, i) => (
+          {sortedLeaders.map((l, i) => (
             <div
               key={l.name}
               className={`w-full max-w-sm md:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)] transition-all duration-700 ease-out ${gridVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
               style={{ transitionDelay: `${i * 150}ms` }}
             >
-              <LeaderCard {...l} />
+              <LeaderCard {...l} past={isPastEvent(l.date)} />
             </div>
           ))}
         </div>

--- a/src/components/RegionsSection.tsx
+++ b/src/components/RegionsSection.tsx
@@ -1,9 +1,19 @@
 import BrazilMapSVG from "./BrazilMapSVG";
 import { useScrollAnimation } from "@/hooks/use-scroll-animation";
+import { useNavigate } from "react-router-dom";
 
 const RegionsSection = () => {
   const { ref: titleRef, isVisible: titleVisible } = useScrollAnimation();
   const { ref: mapRef, isVisible: mapVisible } = useScrollAnimation();
+  const navigate = useNavigate();
+
+  const regions = [
+    { name: "Norte", color: "#554492", link: "/norte/" },
+    { name: "Nordeste", color: "#E69019", link: "/nordeste/" },
+    { name: "Centro-Oeste", color: "#FBC064", link: "/centro-oeste/" },
+    { name: "Sudeste", color: "#77889D", link: "/sudeste/" },
+    { name: "Sul", color: "#322F5A", link: "/sul/" },
+  ];
 
   return (
     <section id="regioes" className="py-24">
@@ -25,20 +35,18 @@ const RegionsSection = () => {
         >
           <BrazilMapSVG />
         </div>
-        <div className={`flex justify-center gap-6 mt-8 flex-wrap transition-all duration-700 ease-out ${mapVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"}`}
+        <div className={`flex justify-center gap-3 mt-8 flex-wrap transition-all duration-700 ease-out ${mapVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"}`}
           style={{ transitionDelay: "400ms" }}
         >
-          {[
-            { name: "Norte", color: "#554492" },
-            { name: "Nordeste", color: "#E69019" },
-            { name: "Centro-Oeste", color: "#FBC064" },
-            { name: "Sudeste", color: "#77889D" },
-            { name: "Sul", color: "#322F5A" },
-          ].map((r) => (
-            <div key={r.name} className="flex items-center gap-2">
-              <div className="w-4 h-4 rounded-sm" style={{ backgroundColor: r.color }} />
-              <span className="text-sm text-muted-foreground font-display">{r.name}</span>
-            </div>
+          {regions.map((r) => (
+            <button
+              key={r.name}
+              onClick={() => navigate(r.link)}
+              className="flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-card/50 hover:bg-card hover:border-primary/50 transition-all duration-200 cursor-pointer group"
+            >
+              <div className="w-3 h-3 rounded-full group-hover:scale-110 transition-transform" style={{ backgroundColor: r.color }} />
+              <span className="text-sm text-muted-foreground group-hover:text-foreground font-display transition-colors">{r.name}</span>
+            </button>
           ))}
         </div>
       </div>

--- a/src/regions/RegionPage.tsx
+++ b/src/regions/RegionPage.tsx
@@ -9,6 +9,7 @@ import CallForSponsorsSection from "./components/CallForSponsorsSection";
 import SpeakersSection from "./components/SpeakersSection";
 import ScheduleSection from "./components/ScheduleSection";
 import SponsorsSection from "./components/SponsorsSection";
+import CommunitiesSection from "./components/CommunitiesSection";
 import OrganizersSection from "./components/OrganizersSection";
 import RegionFooter from "./components/RegionFooter";
 import SeoHead from "@/components/SeoHead";
@@ -24,8 +25,17 @@ interface RegionPageProps {
 
 const BASE_URL = "https://awscommunityday.com.br";
 
+function isPastEvent(targetDate: string): boolean {
+  const eventDate = new Date(targetDate);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return eventDate < today;
+}
+
 const RegionPage = ({ config, organizers, speakers, schedule, sponsors, heroImage }: RegionPageProps) => {
   useEffect(() => { window.scrollTo(0, 0); }, []);
+
+  const past = isPastEvent(config.targetDate);
 
   const targetDateObj = new Date(config.targetDate);
   const formattedDate = `${String(targetDateObj.getDate()).padStart(2, "0")}/${String(targetDateObj.getMonth() + 1).padStart(2, "0")}/${targetDateObj.getFullYear()}`;
@@ -42,7 +52,7 @@ const RegionPage = ({ config, organizers, speakers, schedule, sponsors, heroImag
     name: `AWS Community Day Brasil 2026 - ${config.regionName}`,
     startDate: config.targetDate,
     eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
-    eventStatus: "https://schema.org/EventScheduled",
+    eventStatus: past ? "https://schema.org/EventCompleted" : "https://schema.org/EventScheduled",
     location: {
       "@type": "Place",
       name: config.location.venue,
@@ -86,15 +96,16 @@ const RegionPage = ({ config, organizers, speakers, schedule, sponsors, heroImag
           jsonLd: [eventJsonLd],
         }}
       />
-      <RegionHeader registrationUrl={config.registration.url} />
-      <RegionHero config={config} heroImage={heroImage} />
-      <InfoCardsSection config={config} formattedDate={formattedDate} />
-      {config.callForSpeakersUrl && <CallForSpeakersSection url={config.callForSpeakersUrl} config={config} formattedDate={formattedDate} />}
-      <ExpectationsSection />
-      <SpeakersSection speakers={speakers} />
+      <RegionHeader registrationUrl={past ? undefined : config.registration.url} />
+      <RegionHero config={config} heroImage={heroImage} past={past} />
+      <InfoCardsSection config={config} formattedDate={formattedDate} past={past} />
+      {!past && config.callForSpeakersUrl && <CallForSpeakersSection url={config.callForSpeakersUrl} config={config} formattedDate={formattedDate} />}
+      {!past && <ExpectationsSection />}
+      <SpeakersSection speakers={speakers} past={past} />
       <ScheduleSection schedule={schedule} hasSpeakers={speakers.length > 0} />
-      {config.callForSponsorsUrl && <CallForSponsorsSection url={config.callForSponsorsUrl} config={config} />}
+      {!past && config.callForSponsorsUrl && <CallForSponsorsSection url={config.callForSponsorsUrl} config={config} />}
       <SponsorsSection sponsors={sponsors} />
+      {past && config.pastEvent?.communities && <CommunitiesSection communities={config.pastEvent.communities} />}
       <OrganizersSection organizers={organizers} />
       <RegionFooter config={config} />
     </div>

--- a/src/regions/centro-oeste/data/config.json
+++ b/src/regions/centro-oeste/data/config.json
@@ -31,5 +31,25 @@
   "contact": {
     "email": "centrooeste@awscommunity.com.br",
     "website": "https://www.awscommunityday.com.br"
+  },
+  "pastEvent": {
+    "photosUrl": "https://photos.app.goo.gl/K2NxYNw5ySWGgxC7A",
+    "communities": [
+      {
+        "name": "AWS User Group Brasília",
+        "url": "https://www.instagram.com/awsbrasilia/",
+        "icon": "instagram"
+      },
+      {
+        "name": "AWS User Group Goiânia",
+        "url": "https://www.instagram.com/awsgoiania/",
+        "icon": "instagram"
+      },
+      {
+        "name": "AWS User Group Anápolis",
+        "url": "https://www.instagram.com/awsusergroupanapolis/",
+        "icon": "instagram"
+      }
+    ]
   }
 }

--- a/src/regions/components/CommunitiesSection.tsx
+++ b/src/regions/components/CommunitiesSection.tsx
@@ -1,0 +1,75 @@
+import { useScrollAnimation } from "@/hooks/use-scroll-animation";
+
+interface Community {
+  name: string;
+  url: string;
+  icon?: string;
+}
+
+interface CommunitiesSectionProps {
+  communities: Community[];
+}
+
+const CommunitiesSection = ({ communities }: CommunitiesSectionProps) => {
+  const { ref, isVisible } = useScrollAnimation();
+
+  if (communities.length === 0) return null;
+
+  return (
+    <section className="py-20 scroll-mt-16">
+      <div className="container max-w-4xl">
+        <div
+          ref={ref}
+          className={`text-center mb-12 transition-all duration-700 ease-out ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"}`}
+        >
+          <p className="text-sm font-semibold tracking-[0.3em] uppercase text-primary mb-3 font-display">
+            Comunidades
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold font-display text-foreground">
+            Conheça as comunidades da região
+          </h2>
+          <p className="text-muted-foreground mt-4 max-w-2xl mx-auto">
+            Participe dos grupos de usuários AWS da região e continue aprendendo e conectando com a comunidade.
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-center gap-4">
+          {communities.map((community, i) => (
+            <a
+              key={community.name}
+              href={community.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`flex items-center gap-3 px-6 py-4 rounded-lg border border-border bg-card hover:border-primary/50 hover:bg-card/80 transition-all duration-700 ease-out group ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
+              style={{ transitionDelay: `${i * 150}ms`, boxShadow: "var(--shadow-card)" }}
+            >
+              {community.icon === "instagram" && (
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-primary group-hover:scale-110 transition-transform">
+                  <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                  <path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37z" />
+                  <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+                </svg>
+              )}
+              {!community.icon && (
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-primary group-hover:scale-110 transition-transform">
+                  <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
+                </svg>
+              )}
+              <span className="text-sm font-semibold font-display text-foreground group-hover:text-primary transition-colors">
+                {community.name}
+              </span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted-foreground group-hover:text-primary transition-colors ml-1">
+                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CommunitiesSection;

--- a/src/regions/components/InfoCardsSection.tsx
+++ b/src/regions/components/InfoCardsSection.tsx
@@ -4,9 +4,10 @@ import type { RegionConfig } from "@/regions/types";
 interface InfoCardsSectionProps {
   config: RegionConfig;
   formattedDate: string;
+  past?: boolean;
 }
 
-const InfoCardsSection = ({ config, formattedDate }: InfoCardsSectionProps) => {
+const InfoCardsSection = ({ config, formattedDate, past = false }: InfoCardsSectionProps) => {
   const { ref, isVisible } = useScrollAnimation();
 
   // Format date from targetDate
@@ -21,11 +22,19 @@ const InfoCardsSection = ({ config, formattedDate }: InfoCardsSectionProps) => {
   const dateValue = isTimeRange || !config.eventTime ? dateStr : config.eventTime;
   const timeSub = isTimeRange ? config.eventTime! : config.eventTime ? `Previsão: ${dateStr}` : formattedDate;
 
-  const cards = [
-    { label: "Local", value: config.location.venue, sub: config.location.city, icon: "M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z" },
-    { label: "Data e Hora", value: dateValue, sub: timeSub, icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" },
-    { label: "Inscrições", value: config.registration.status, sub: config.registration.url ? "Inscreva-se" : "Fique ligado", href: config.registration.url || undefined, icon: "M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" },
-  ];
+  const cards = past
+    ? [
+        { label: "Local", value: config.location.venue, sub: config.location.city, icon: "M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z" },
+        { label: "Realizado em", value: dateValue, sub: timeSub, icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" },
+        ...(config.pastEvent?.photosUrl
+          ? [{ label: "Galeria", value: "Veja as fotos", sub: "Ver fotos →", href: config.pastEvent.photosUrl, icon: "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" }]
+          : []),
+      ]
+    : [
+        { label: "Local", value: config.location.venue, sub: config.location.city, icon: "M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z" },
+        { label: "Data e Hora", value: dateValue, sub: timeSub, icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" },
+        { label: "Inscrições", value: config.registration.status, sub: config.registration.url ? "Inscreva-se" : "Fique ligado", href: config.registration.url || undefined, icon: "M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" },
+      ];
 
   return (
     <section id="sobre" className="py-8 scroll-mt-16">

--- a/src/regions/components/RegionHero.tsx
+++ b/src/regions/components/RegionHero.tsx
@@ -27,9 +27,10 @@ function useCountdown(targetDate: string) {
 interface RegionHeroProps {
   config: RegionConfig;
   heroImage: string;
+  past?: boolean;
 }
 
-const RegionHero = ({ config, heroImage }: RegionHeroProps) => {
+const RegionHero = ({ config, heroImage, past = false }: RegionHeroProps) => {
   const { ref, isVisible } = useScrollAnimation();
   const countdown = useCountdown(config.targetDate);
 
@@ -48,16 +49,42 @@ const RegionHero = ({ config, heroImage }: RegionHeroProps) => {
         <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto font-body mb-10">
           {config.subtitle}
         </p>
-        <div className="flex justify-center gap-4 md:gap-8">
-          {([["days", "Dias"], ["hours", "Horas"], ["minutes", "Min"], ["seconds", "Seg"]] as const).map(([key, label]) => (
-            <div key={key} className="flex flex-col items-center">
-              <span className="text-4xl md:text-6xl font-bold font-display text-primary tabular-nums">
-                {String(countdown[key]).padStart(2, "0")}
-              </span>
-              <span className="text-xs md:text-sm text-muted-foreground mt-1 font-display uppercase tracking-wider">{label}</span>
-            </div>
-          ))}
-        </div>
+        {past ? (
+          <div className="flex flex-col items-center gap-4">
+            <span className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-primary/15 border border-primary/30 text-primary font-bold font-display text-lg uppercase tracking-wider">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+              Evento Realizado
+            </span>
+            {config.pastEvent?.photosUrl && (
+              <a
+                href={config.pastEvent.photosUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground font-semibold rounded-full hover:bg-primary/90 transition-colors text-sm"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                  <circle cx="8.5" cy="8.5" r="1.5" />
+                  <polyline points="21 15 16 10 5 21" />
+                </svg>
+                Ver fotos do evento
+              </a>
+            )}
+          </div>
+        ) : (
+          <div className="flex justify-center gap-4 md:gap-8">
+            {([["days", "Dias"], ["hours", "Horas"], ["minutes", "Min"], ["seconds", "Seg"]] as const).map(([key, label]) => (
+              <div key={key} className="flex flex-col items-center">
+                <span className="text-4xl md:text-6xl font-bold font-display text-primary tabular-nums">
+                  {String(countdown[key]).padStart(2, "0")}
+                </span>
+                <span className="text-xs md:text-sm text-muted-foreground mt-1 font-display uppercase tracking-wider">{label}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/regions/components/SpeakersSection.tsx
+++ b/src/regions/components/SpeakersSection.tsx
@@ -4,9 +4,10 @@ import SpeakerCard from "./SpeakerCard";
 
 interface SpeakersSectionProps {
   speakers: Speaker[];
+  past?: boolean;
 }
 
-const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
+const SpeakersSection = ({ speakers, past = false }: SpeakersSectionProps) => {
   const { ref, isVisible } = useScrollAnimation();
 
   if (speakers.length === 0) return null;
@@ -22,7 +23,7 @@ const SpeakersSection = ({ speakers }: SpeakersSectionProps) => {
       <div className="container max-w-5xl">
         <div ref={ref} className={`text-center mb-12 transition-all duration-700 ease-out ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"}`}>
           <p className="text-sm font-semibold tracking-[0.3em] uppercase text-primary mb-3 font-display">Palestrantes</p>
-          <h2 className="text-3xl md:text-4xl font-bold font-display text-foreground">Quem vai palestrar</h2>
+          <h2 className="text-3xl md:text-4xl font-bold font-display text-foreground">{past ? "Quem palestrou" : "Quem vai palestrar"}</h2>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {sortedSpeakers.map((speaker, i) => (

--- a/src/regions/types.ts
+++ b/src/regions/types.ts
@@ -26,6 +26,10 @@ export interface RegionConfig {
     email: string;
     website: string;
   };
+  pastEvent?: {
+    photosUrl?: string;
+    communities?: Array<{ name: string; url: string; icon?: string }>;
+  };
 }
 
 export interface Organizer {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,27 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "fs";
 import { componentTagger } from "lovable-tagger";
+
+// Plugin to serve index.html from public subdirectories (like a static server)
+function publicIndexPlugin() {
+  return {
+    name: "serve-public-index",
+    configureServer(server: any) {
+      server.middlewares.use((req: any, _res: any, next: any) => {
+        const url = req.url?.split("?")[0] ?? "";
+        if (url.endsWith("/")) {
+          const filePath = path.resolve(__dirname, "public", url.slice(1), "index.html");
+          if (fs.existsSync(filePath)) {
+            req.url = url + "index.html";
+          }
+        }
+        next();
+      });
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -13,7 +33,7 @@ export default defineConfig(({ mode }) => ({
       overlay: false,
     },
   },
-  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+  plugins: [publicIndexPlugin(), react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
…ados

- Reordenar líderes na home: futuros primeiro, passados ao final com tag Realizado

- Trocar legenda do mapa por botões clicáveis para cada região

- Adaptar página de região para evento passado (hero, info cards, speakers)

- Criar CommunitiesSection com links das comunidades do Centro-Oeste

- Adicionar página estática de resultados com gráficos interativos (Chart.js)

- Plugin Vite para servir index.html de subpastas do public em dev