### PR TITLE
Update og-image cache versions across all regional pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
     <meta property="og:locale" content="pt_BR" />
     <meta property="og:title" content="AWS Community Day Brasil 2026" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 — pela primeira vez em todas as 5 regiões do país." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/home.png?v=20260610" />
-    <meta property="og:image:secure_url" content="https://awscommunityday.com.br/og/home.png?v=20260610" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/home.png?v=20260717" />
+    <meta property="og:image:secure_url" content="https://awscommunityday.com.br/og/home.png?v=20260717" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -25,9 +25,9 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 — pela primeira vez em todas as 5 regiões do país." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/home.png?v=20260610" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/home.png?v=20260717" />
     <meta name="twitter:image:alt" content="Identidade visual do AWS Community Day Brasil 2026" />
-    <link rel="image_src" href="https://awscommunityday.com.br/og/home.png?v=20260610" />
+    <link rel="image_src" href="https://awscommunityday.com.br/og/home.png?v=20260717" />
 
     <script type="application/ld+json">
       {

--- a/public/centro-oeste/index.html
+++ b/public/centro-oeste/index.html
@@ -13,7 +13,7 @@
     <meta property="og:url" content="https://awscommunityday.com.br/centro-oeste/" />
     <meta property="og:title" content="AWS Community Day Brasil 2026 - Centro-Oeste (Taguatinga/DF)" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 - Centro-Oeste. Compartilhe e participe da edicao de Taguatinga." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/centro-oeste.png" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/centro-oeste.png?v=20260717" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Postcard oficial da edicao Centro-Oeste" />
@@ -21,7 +21,7 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/centro-oeste/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026 - Centro-Oeste (Taguatinga/DF)" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 - Centro-Oeste. Compartilhe e participe da edicao de Taguatinga." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/centro-oeste.png" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/centro-oeste.png?v=20260717" />
     <script>
       sessionStorage.redirect = location.href;
       location.replace('/');

--- a/public/nordeste/index.html
+++ b/public/nordeste/index.html
@@ -13,7 +13,7 @@
     <meta property="og:url" content="https://awscommunityday.com.br/nordeste/" />
     <meta property="og:title" content="AWS Community Day Brasil 2026 - Nordeste (Salvador/BA)" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 - Nordeste. Compartilhe e participe da edicao de Salvador." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/nordeste.png" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/nordeste.png?v=20260717" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Postcard oficial da edicao Nordeste" />
@@ -21,7 +21,7 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/nordeste/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026 - Nordeste (Salvador/BA)" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 - Nordeste. Compartilhe e participe da edicao de Salvador." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/nordeste.png" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/nordeste.png?v=20260717" />
     <script>
       sessionStorage.redirect = location.href;
       location.replace('/');

--- a/public/norte/index.html
+++ b/public/norte/index.html
@@ -13,7 +13,7 @@
     <meta property="og:url" content="https://awscommunityday.com.br/norte/" />
     <meta property="og:title" content="AWS Community Day Brasil 2026 - Norte (Belem/PA)" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 - Norte. Compartilhe e participe da edicao de Belem." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/norte.png" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/norte.png?v=20260717" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Postcard oficial da edicao Norte em Belem" />
@@ -21,7 +21,7 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/norte/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026 - Norte (Belem/PA)" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 - Norte. Compartilhe e participe da edicao de Belem." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/norte.png" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/norte.png?v=20260717" />
     <script>
       sessionStorage.redirect = location.href;
       location.replace('/');

--- a/public/sudeste/index.html
+++ b/public/sudeste/index.html
@@ -13,7 +13,7 @@
     <meta property="og:url" content="https://awscommunityday.com.br/sudeste/" />
     <meta property="og:title" content="AWS Community Day Brasil 2026 - Sudeste (Belo Horizonte/MG)" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 - Sudeste. Compartilhe e participe da edicao de Belo Horizonte." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/sudeste.png" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/sudeste.png?v=20260717" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Postcard oficial da edicao Sudeste" />
@@ -21,7 +21,7 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/sudeste/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026 - Sudeste (Belo Horizonte/MG)" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 - Sudeste. Compartilhe e participe da edicao de Belo Horizonte." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/sudeste.png" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/sudeste.png?v=20260717" />
     <script>
       sessionStorage.redirect = location.href;
       location.replace('/');

--- a/public/sul/index.html
+++ b/public/sul/index.html
@@ -13,7 +13,7 @@
     <meta property="og:url" content="https://awscommunityday.com.br/sul/" />
     <meta property="og:title" content="AWS Community Day Brasil 2026 - Sul (Curitiba/PR)" />
     <meta property="og:description" content="AWS Community Day Brasil 2026 - Sul. Compartilhe e participe da edicao de Curitiba." />
-    <meta property="og:image" content="https://awscommunityday.com.br/og/sul.png" />
+    <meta property="og:image" content="https://awscommunityday.com.br/og/sul.png?v=20260717" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Postcard oficial da edicao Sul" />
@@ -21,7 +21,7 @@
     <meta name="twitter:url" content="https://awscommunityday.com.br/sul/" />
     <meta name="twitter:title" content="AWS Community Day Brasil 2026 - Sul (Curitiba/PR)" />
     <meta name="twitter:description" content="AWS Community Day Brasil 2026 - Sul. Compartilhe e participe da edicao de Curitiba." />
-    <meta name="twitter:image" content="https://awscommunityday.com.br/og/sul.png" />
+    <meta name="twitter:image" content="https://awscommunityday.com.br/og/sul.png?v=20260717" />
     <script>
       sessionStorage.redirect = location.href;
       location.replace('/');


### PR DESCRIPTION
Adiciona parâmetro de versão (?v=20260717) em todas as URLs de og:image e twitter:image para invalidar o cache de previews do WhatsApp e outras plataformas que fazem scraping de meta tags.